### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ An MCP server that implements branch-based thought navigation, with support for:
 This is based on the `sequential-thinking` tool available here:
 https://github.com/modelcontextprotocol/servers/tree/main/src/sequentialthinking
 
+<a href="https://glama.ai/mcp/servers/i9a4t5f68z"><img width="380" height="200" src="https://glama.ai/mcp/servers/i9a4t5f68z/badge" alt="Branch Thinking Server MCP server" /></a>
+
 ## Features
 
 - **Branch Management**: Create and navigate between different lines of thought


### PR DESCRIPTION
This PR adds a badge for the [Branch Thinking MCP Server](https://glama.ai/mcp/servers/i9a4t5f68z) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/i9a4t5f68z"><img width="380" height="200" src="https://glama.ai/mcp/servers/i9a4t5f68z/badge" alt="Branch Thinking Server MCP server" /></a>

Glama performs regular codebase and documentation scans to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.